### PR TITLE
feat: 🌟 support mixed type metric results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,6 @@ Second, a new metric entry must be added under the `metrics` key. Each entry’s
 | evidence          | 1-5 `int`; rating of evidence for this metric |
 | relevance         | 1-5 `int`; rating of relevance for this metric |
 | speed             | 0-2 `int`; 0=Slow, 1=Medium, 2=Fast |
-| visualizationType | `table` or `b64`, table=numerical results, b64=image results |
 | references        | List of `references` entries specifying references, see description below |
 | results           | List of `results` entries specifying results, see description below |
 
@@ -57,7 +56,7 @@ Second, a new metric entry must be added under the `metrics` key. Each entry’s
 |:------------|:------------|
 | id          | Result ID, format is metric ID + underscore + index in the array returned by the metric |
 | index       | Index in the metric result array |
-| type        | `int`, `float`, or `b64` |
+| type        | `int`, `float`, or `b64` (image) |
 | name        | Result name |
 | description | Optional result description. `false` if there is no description |
 | scores      | List of `scores` entries specifying scores, see description below |

--- a/frontend/src/components/Results.vue
+++ b/frontend/src/components/Results.vue
@@ -47,18 +47,23 @@
                           <font-awesome-icon :icon="['far', 'star']" />
                         </span>
                       </p>
-                      <template v-if="metrics[metric].visualizationType==='table'">
-                        <b-table striped hover :items="results[metric]" :fields="resultTableFields" class="mt-4">
-                          <template #cell(result)="data">
-                            {{ data.value.name }}
-                            <template v-if="data.value.description">
-                              <span v-b-tooltip.hover :title="data.value.description">
-                                <font-awesome-icon :icon="['fas', 'question-circle']" />
-                              </span>
-                            </template>
+                      <b-table striped hover :items="results[metric]" :fields="resultTableFields" class="mt-4">
+                        <template #cell(result)="data">
+                          {{ data.item.result.name }}
+                          <template v-if="data.item.result.description">
+                            <span v-b-tooltip.hover :title="data.item.result.description">
+                              <font-awesome-icon :icon="['fas', 'question-circle']" />
+                            </span>
                           </template>
-                          <template #cell(evaluation)="data">
-                            <div v-if="metrics[metric].results[data.index].scores.length > 1" :id="data.item.id" class="scores">
+                        </template>
+                        <template #cell(value)="data">
+                          <template v-if="data.item.result.type!=='b64'">
+                            {{ data.item.value }}
+                          </template>
+                        </template>
+                        <template #cell(evaluation)="data">
+                          <template v-if="data.item.result.type!=='b64'">
+                            <div v-if="metrics[metric].results[data.index].scores && metrics[metric].results[data.index].scores.length > 1" :id="data.item.id" class="scores">
                               <div v-for="score in metrics[metric].results[data.index].scores" :key="score.description">
                                 <div v-show="getJudgment(score, data.item.value)" :class="score.judgment" class="score">
                                   {{ score.description }}
@@ -69,10 +74,12 @@
                               </div>
                             </div>
                             <div v-else :id="data.item.id">
-                              <span>-</span>
+                              -
                             </div>
                           </template>
-                          <template #cell(show_details)="data">
+                        </template>
+                        <template #cell(show_details)="data">
+                          <template v-if="data.item.result.type!=='b64'">
                             <b-btn v-b-modal="`${data.item.id}-modal`" variant="link">Show Details</b-btn>
                             <b-modal :id="`${data.item.id}-modal`" :title="data.item.result.name" size="lg" ok-only ok-title="Close">
                               <template v-if="data.item.result.description">
@@ -92,20 +99,11 @@
                               <p style="font-size: 11px;"><sup>*</sup>Country-specific, non-representative, and non-relevant sites were excluded from the list.</p>
                             </b-modal>
                           </template>
-                        </b-table>
-                      </template>
-                      <template v-else-if="metrics[metric].visualizationType==='b64'">
-                        <template v-for="(result, resultIdx) in results[metric]">
-                          <div :id="result.id" :key="resultIdx" class="b64">
-                            <h3 class="mt-2">{{ result.result.name }}</h3>
-                            <p v-if="result.result.description">{{ result.result.description }}</p>
-                            <img v-if="result.value !== ''" class="result-img" :src="'data:image/png;base64, ' + result.value">
-                            <p v-else class="alert alert-danger" role="alert">
-                              <strong>Whoops!</strong> Our experimental visual search performance metric failed to evaluate your image, please try again with a different one.
-                            </p>
-                          </div>
                         </template>
-                      </template>
+                        <template #row-details="data">
+                          <img v-if="data.item.result.type==='b64'" class="result-img" :src="'data:image/png;base64, ' + data.item.value">
+                        </template>
+                      </b-table>
                     </b-card-body>
                   </b-collapse>
                 </b-card>

--- a/frontend/src/components/Summary.vue
+++ b/frontend/src/components/Summary.vue
@@ -41,40 +41,36 @@
                       </div>
                     </a>
                   </div>
-                  <div v-if="metrics[metric].visualizationType==='table'">
-                    <div v-for="(result, i) in metrics[metric].results" :key="i" class="result">
+                  <div>
+                    <div v-for="(result, resultIdx) in metrics[metric].results" :key="resultIdx" class="result">
                       <div class="info">
                         <a :href="'#'+ result.id">
                           <div class="result-name">{{ result.name }}</div>
                         </a>
                       </div>
-                      <span v-if="result.scores.length > 1">
-                        <template v-for="(score, scoreIdx) in result.scores">
-                          <div v-show="getJudgment(score, results[metric][i].value)" :key="scoreIdx" class="score">
-                            <div class="description" :class="score.judgment">
-                              {{ score.description }}
-                              <template v-if="(score.icon[0]!=null)">
-                                <font-awesome-icon :icon="score.icon" />
-                              </template>
-                            </div>
-                          </div>
-                        </template>
-                      </span>
-                    </div>
-                  </div>
-
-                  <div v-if="metrics[metric].visualizationType==='b64'" class="results">
-                    <div v-for="(result, resultIdx) in results[metric]" :key="resultIdx" class="result">
-                      <div class="info">
-                        <a :href="'#'+ result.id">
-                          <span>{{ result.result.name }}</span>
-                        </a>
+                      <!-- If result type is an image (PNG) encoded in Base64 -->
+                      <div v-if="result.type==='b64'">
+                        <img
+                          v-if="results[metric][resultIdx].value !== ''"
+                          class="result-img"
+                          :src="'data:image/png;base64, ' + results[metric][resultIdx].value"
+                        >
                       </div>
-                      <img
-                        v-if="result.value !== ''"
-                        class="result-img"
-                        :src="'data:image/png;base64, ' + result.value"
-                      >
+                      <!-- If result type is int or float -->
+                      <div v-else>
+                        <span v-if="result.scores && result.scores.length > 1">
+                          <template v-for="(score, scoreIdx) in result.scores">
+                            <div v-show="getJudgment(score, results[metric][resultIdx].value)" :key="scoreIdx" class="score">
+                              <div class="description" :class="score.judgment">
+                                {{ score.description }}
+                                <template v-if="(score.icon[0]!=null)">
+                                  <font-awesome-icon :icon="score.icon" />
+                                </template>
+                              </div>
+                            </div>
+                          </template>
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div><!-- metric -->

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -42,10 +42,11 @@ const getters = {
             id: metrics[key].results[index].id,
             result: {
               name: metrics[key].results[index].name,
+              type: metrics[key].results[index].type,
               description: metrics[key].results[index].description
             },
             value: result,
-            _show_details: false
+            _showDetails: metrics[key].results[index].type === 'b64' ? true : false
           })
         })
         results[key] = metricResults

--- a/metrics.json
+++ b/metrics.json
@@ -33,7 +33,6 @@
       "evidence": 1,
       "relevance": 2,
       "speed": 2,
-      "visualizationType": "table",
       "references": [
         {
           "title": "Miniukovich, A. and De Angeli, A. (2015). Computation of Interface Aesthetics. In Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems (CHI '15), pp. 1163-1172. ACM. doi: https://doi.org/10.1145/2702123.2702575",
@@ -88,7 +87,6 @@
       "evidence": 2,
       "relevance": 3,
       "speed": 2,
-      "visualizationType": "table",
       "references": [
         {
           "title": "Miniukovich, A. and De Angeli, A. (2015). Computation of Interface Aesthetics. In Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems (CHI '15), pp. 1163-1172. ACM. doi: https://doi.org/10.1145/2702123.2702575",
@@ -151,7 +149,6 @@
       "evidence": 2,
       "relevance": 2,
       "speed": 2,
-      "visualizationType": "table",
       "references": [
         {
           "title": "Miniukovich, A. and De Angeli, A. (2015). Computation of Interface Aesthetics. In Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems (CHI '15), pp. 1163-1172. ACM. doi: https://doi.org/10.1145/2702123.2702575",
@@ -206,7 +203,6 @@
       "evidence": 4,
       "relevance": 3,
       "speed": 2,
-      "visualizationType": "table",
       "references": [
         {
           "title": "Miniukovich, A. and De Angeli, A. (2015). Computation of Interface Aesthetics. In Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems (CHI '15), pp. 1163-1172. ACM. doi: https://doi.org/10.1145/2702123.2702575",
@@ -265,7 +261,6 @@
       "evidence": 3,
       "relevance": 4,
       "speed": 2,
-      "visualizationType": "table",
       "references": [
         {
           "title": "Miniukovich, A. and De Angeli, A. (2015). Computation of Interface Aesthetics. In Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems (CHI '15), pp. 1163-1172. ACM. doi: https://doi.org/10.1145/2702123.2702575",
@@ -332,7 +327,6 @@
       "evidence": 3,
       "relevance": 3,
       "speed": 1,
-      "visualizationType": "table",
       "references": [
         {
           "title": "Miniukovich, A. and De Angeli, A. (2015). Computation of Interface Aesthetics. In Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems (CHI '15), pp. 1163-1172. ACM. doi: https://doi.org/10.1145/2702123.2702575",
@@ -399,7 +393,6 @@
       "evidence": 3,
       "relevance": 3,
       "speed": 1,
-      "visualizationType": "table",
       "references": [
         {
           "title": "Miniukovich, A. and De Angeli, A. (2015). Computation of Interface Aesthetics. In Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems (CHI '15), pp. 1163-1172. ACM. doi: https://doi.org/10.1145/2702123.2702575",
@@ -458,7 +451,6 @@
       "evidence": 3,
       "relevance": 3,
       "speed": 0,
-      "visualizationType": "table",
       "references": [
         {
           "title": "Miniukovich, A. and De Angeli, A. (2015). Computation of Interface Aesthetics. In Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems (CHI '15), pp. 1163-1172. ACM. doi: https://doi.org/10.1145/2702123.2702575",


### PR DESCRIPTION
Hi @vanntile ! I implemented support for mixed type metric results. Could you kindly review the changes made and merge this to the `aim2` branch?

Main changes:
- Removed `visualizationType` (now redundant) from `metrics.json`
- Combined visualization type specific summary tables in `Summary.vue`
- Combined visualization type specific result tables in `Results.vue`
- Refined `resultsFormatted` in `index.js`

The image below shows example metric results for a metric using mixed types.
![mixed](https://user-images.githubusercontent.com/1519259/138564179-d4d39f24-44e6-48cb-b8f0-fb0e4029fce4.png)
